### PR TITLE
Only use hydra id for message

### DIFF
--- a/CiscoWebexTeams.py
+++ b/CiscoWebexTeams.py
@@ -499,11 +499,10 @@ class CiscoWebexTeamsBackend(ErrBot):
             return
 
         activity = message["data"]["activity"]
-        activity["id"] = self.build_hydra_id(activity["id"])
         new_message = None
 
         if activity["verb"] == "post":
-            new_message = self.webex_teams_api.messages.get(activity["id"])
+            new_message = self.webex_teams_api.messages.get(self.build_hydra_id(activity["id"]))
 
             if new_message.personEmail in self.bot_identifier.emails:
                 logging.debug("Ignoring message from myself")

--- a/CiscoWebexTeams.py
+++ b/CiscoWebexTeams.py
@@ -28,7 +28,7 @@ from errbot import rendering
 import webexteamssdk
 from webexteamssdk.models.cards import AdaptiveCard
 
-__version__ = "1.10.0"
+__version__ = "1.11.0"
 
 log = logging.getLogger("errbot.backends.CiscoWebexTeams")
 


### PR DESCRIPTION
This resolve and issue caused by the recently introduced hydra message conversion. While the messages would work fine there would be 404 errors for attachments/cards. Rather than replacing the ID with the updated hydra converted ID, instead only do the conversion when talking to the messages API. 