### PR TITLE
Support invokde function in different plugin

### DIFF
--- a/CiscoWebexTeams.py
+++ b/CiscoWebexTeams.py
@@ -28,7 +28,7 @@ from errbot import rendering
 import webexteamssdk
 from webexteamssdk.models.cards import AdaptiveCard
 
-__version__ = "1.12.0"
+__version__ = "1.13.0"
 
 log = logging.getLogger("errbot.backends.CiscoWebexTeams")
 
@@ -547,6 +547,7 @@ class CiscoWebexTeamsBackend(ErrBot):
         """
         if not callback_card:
             callback_card = "callback_card"
+
         for plugin in self.plugin_manager.get_all_active_plugins():
             plugin_name = plugin.name
             log.debug(f"Triggering {callback_card} on {plugin_name}.",)


### PR DESCRIPTION
Developers may develop different plugins, for example:
```python
class First(BotPlugin):
    def callback_card(self, msg):
        print('first')

class Second(BotPlugin):
    def callback_card(self, msg):
        print('second')
```
It might have sight effect on the above scenario. Because  the `callback_card` will call all plugins

```python
class CiscoWebexTeamsBackend(ErrBot):
        ....
    def callback_card(self, message):
        ....
        for plugin in self.plugin_manager.get_all_active_plugins():
            plugin_name = plugin.name
```

If we allow to define callback,
```python
class First(BotPlugin):
    def fir_callback_card(self, msg):
        print('first')

class Second(BotPlugin):
    def sec_callback_card(self, msg):
        print('second')
```
We can have some flexibility.